### PR TITLE
Mepts 424 (#308) (#309)

### DIFF
--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/generic/NewlyOrPreviouslyEnrolledOnARTCalculation.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/generic/NewlyOrPreviouslyEnrolledOnARTCalculation.java
@@ -12,12 +12,14 @@
 package org.openmrs.module.eptsreports.reporting.calculation.generic;
 
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import org.joda.time.DateTime;
+import org.joda.time.Days;
 import org.joda.time.Months;
 import org.openmrs.Location;
 import org.openmrs.Obs;
@@ -53,6 +55,8 @@ public class NewlyOrPreviouslyEnrolledOnARTCalculation extends AbstractPatientCa
 
   private static final int MINIMUM_DURATION_IN_MONTHS = 6;
 
+  private static final String ON_OR_AFTER = "onOrAfter";
+
   private static final String ON_OR_BEFORE = "onOrBefore";
 
   @Autowired private HivMetadata hivMetadata;
@@ -69,12 +73,19 @@ public class NewlyOrPreviouslyEnrolledOnARTCalculation extends AbstractPatientCa
     boolean isNewlyEnrolledOnArtSearch =
         getBooleanParameter(parameterValues, "isNewlyEnrolledOnArtSearch");
     Location location = (Location) context.getFromCache("location");
+    Date startDate = (Date) parameterValues.get(ON_OR_AFTER);
     Date endDate = (Date) parameterValues.get(ON_OR_BEFORE);
+
+    if (startDate == null) {
+      startDate = (Date) context.getFromCache(ON_OR_AFTER);
+    }
 
     if (endDate == null) {
       endDate = (Date) context.getFromCache(ON_OR_BEFORE);
     }
 
+    // Start ART date is always checked against endDate, not endDate - 6m
+    parameterValues.put("onOrBefore", addMonths(endDate, 6));
     CalculationResultMap artStartDates =
         calculate(
             Context.getRegisteredComponents(InitialArtStartDateCalculation.class).get(0),
@@ -87,7 +98,7 @@ public class NewlyOrPreviouslyEnrolledOnARTCalculation extends AbstractPatientCa
             null,
             location,
             false,
-            null,
+            startDate,
             endDate,
             null,
             cohort,
@@ -100,7 +111,7 @@ public class NewlyOrPreviouslyEnrolledOnARTCalculation extends AbstractPatientCa
             Arrays.asList(location),
             Arrays.asList(hivMetadata.getStartDrugs()),
             TimeQualifier.FIRST,
-            null,
+            startDate,
             endDate,
             context);
     if (endDate != null) {
@@ -115,23 +126,24 @@ public class NewlyOrPreviouslyEnrolledOnARTCalculation extends AbstractPatientCa
             || artStartDate == null) {
           continue;
         }
-        int artMinusIptStartDate =
-            Months.monthsBetween(
-                    new DateTime(artStartDate.getTime()),
-                    new DateTime(
-                        getEarliestIptStartDate(
-                                seguimentoOrFichaResumo, fichaClinicaMasterCardStartDrugsObs)
-                            .getTime()))
-                .getMonths();
+
+        DateTime artStartDateTime = new DateTime(artStartDate.getTime());
+        DateTime iptStartDateTime =
+            new DateTime(
+                getEarliestIptStartDate(
+                        seguimentoOrFichaResumo, fichaClinicaMasterCardStartDrugsObs)
+                    .getTime());
+        boolean isDiffMoreThanSix =
+            isDateDiffGreaterThanSixMonths(artStartDateTime, iptStartDateTime);
         if (artStartDate != null
             && artStartDate.compareTo(endDate) <= 0
-            && artMinusIptStartDate <= MINIMUM_DURATION_IN_MONTHS
+            && isDiffMoreThanSix == false
             && isNewlyEnrolledOnArtSearch == true) {
           map.put(patientId, new BooleanResult(true, this));
         }
         if (artStartDate != null
             && artStartDate.compareTo(endDate) <= 0
-            && artMinusIptStartDate > MINIMUM_DURATION_IN_MONTHS
+            && isDiffMoreThanSix == true
             && isNewlyEnrolledOnArtSearch == false) {
           map.put(patientId, new BooleanResult(true, this));
         }
@@ -171,6 +183,46 @@ public class NewlyOrPreviouslyEnrolledOnARTCalculation extends AbstractPatientCa
           ? getDateFromObs(seguimentoOrFichaResumoDate)
           : fichaClinicaMasterCardDate.getObsDatetime();
     }
+  }
+  /**
+   * Checks if the difference between ART start date and IPT start date is greater than six months,
+   * considering days if the difference in months is equal to 6 months
+   *
+   * @param artStartDateTime The ART start date
+   * @param iptStartDateTime The IPT start date
+   * @return true if the difference is greater to six months, false otherwise.
+   */
+  public boolean isDateDiffGreaterThanSixMonths(
+      DateTime artStartDateTime, DateTime iptStartDateTime) {
+    int artMinusIptStartDate =
+        Months.monthsBetween(new DateTime(artStartDateTime), new DateTime(iptStartDateTime))
+            .getMonths();
+    if (artMinusIptStartDate > MINIMUM_DURATION_IN_MONTHS) {
+      return true;
+    }
+    if (artMinusIptStartDate
+        == MINIMUM_DURATION_IN_MONTHS) { // Check if there are some days after the six months (eg. 6
+      // Months and 4 days)
+      DateTime newEnd = iptStartDateTime.minusMonths(artMinusIptStartDate);
+      int days = Days.daysBetween(artStartDateTime, newEnd).getDays();
+      if (days > 0) {
+        return true;
+      }
+    }
+    return false;
+  }
+  /**
+   * Adds a number of months to the passed-in date
+   *
+   * @param date the date to increment
+   * @param monthsToAdd the number of months to add
+   * @return date incremented by {monthsToAdd} months
+   */
+  public static Date addMonths(Date date, int monthsToAdd) {
+    Calendar cal = Calendar.getInstance();
+    cal.setTime(date);
+    cal.add(Calendar.MONTH, monthsToAdd);
+    return cal.getTime();
   }
 
   private boolean getBooleanParameter(Map<String, Object> parameterValues, String parameterName) {

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/GenericCohortQueries.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/GenericCohortQueries.java
@@ -409,6 +409,7 @@ public class GenericCohortQueries {
     cd.setName("Newly Or Previously Enrolled On ART");
     cd.addCalculationParameter("isNewlyEnrolledOnArtSearch", isNewlyEnrolledOnArtSearch);
     cd.addParameter(new Parameter("location", "Location", Location.class));
+    cd.addParameter(new Parameter("onOrAfter", "After Date", Date.class));
     cd.addParameter(new Parameter("onOrBefore", "Before Date", Date.class));
     return cd;
   }

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/TbPrevCohortQueries.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/TbPrevCohortQueries.java
@@ -78,7 +78,7 @@ public class TbPrevCohortQueries {
         "started-by-end-previous-reporting-period",
         EptsReportUtils.map(
             genericCohortQueries.getStartedArtBeforeDate(false),
-            "onOrBefore=${onOrBefore-6m},location=${location}"));
+            "onOrBefore=${onOrBefore},location=${location}"));
     definition.addSearch(
         "completed-isoniazid",
         EptsReportUtils.map(
@@ -92,13 +92,14 @@ public class TbPrevCohortQueries {
   public CohortDefinition getNewOnArt() {
     CompositionCohortDefinition definition = new CompositionCohortDefinition();
     definition.setName("TB-PREV New on ART");
+    definition.addParameter(new Parameter("onOrAfter", "After Date", Date.class));
     definition.addParameter(new Parameter("onOrBefore", "Before Date", Date.class));
     definition.addParameter(new Parameter("location", "Location", Location.class));
     definition.addSearch(
         "started-on-previous-period",
         EptsReportUtils.map(
             genericCohortQueries.getNewlyOrPreviouslyEnrolledOnART(true),
-            "onOrBefore=${onOrBefore-6m},location=${location}"));
+            "onOrAfter=${onOrAfter-6m},onOrBefore=${onOrBefore-6m},location=${location}"));
     definition.setCompositionString("started-on-previous-period");
     return definition;
   }
@@ -106,13 +107,14 @@ public class TbPrevCohortQueries {
   public CohortDefinition getPreviouslyOnArt() {
     CompositionCohortDefinition definition = new CompositionCohortDefinition();
     definition.setName("TB-PREV Previously on ART");
+    definition.addParameter(new Parameter("onOrAfter", "After Date", Date.class));
     definition.addParameter(new Parameter("onOrBefore", "Before Date", Date.class));
     definition.addParameter(new Parameter("location", "Location", Location.class));
     definition.addSearch(
         "started-by-end-previous-reporting-period",
         EptsReportUtils.map(
             genericCohortQueries.getNewlyOrPreviouslyEnrolledOnART(false),
-            "onOrBefore=${onOrBefore-6m},location=${location}"));
+            "onOrAfter=${onOrAfter-6m},onOrBefore=${onOrBefore-6m},location=${location}"));
     definition.setCompositionString("started-by-end-previous-reporting-period");
     return definition;
   }
@@ -127,7 +129,7 @@ public class TbPrevCohortQueries {
         "started-by-end-previous-reporting-period",
         EptsReportUtils.map(
             genericCohortQueries.getStartedArtBeforeDate(false),
-            "onOrBefore=${onOrBefore-6m},location=${location}"));
+            "onOrBefore=${onOrBefore},location=${location}"));
     definition.addSearch(
         "started-isoniazid",
         EptsReportUtils.map(

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/dimensions/EptsCommonDimension.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/dimensions/EptsCommonDimension.java
@@ -276,12 +276,13 @@ public class EptsCommonDimension {
     dim.addCohortDefinition(
         "new-on-art",
         EptsReportUtils.map(
-            tbPrevCohortQueries.getNewOnArt(), "onOrBefore=${onOrBefore},location=${location}"));
+            tbPrevCohortQueries.getNewOnArt(),
+            "onOrAfter=${onOrAfter},onOrBefore=${onOrBefore},location=${location}"));
     dim.addCohortDefinition(
         "previously-on-art",
         EptsReportUtils.map(
             tbPrevCohortQueries.getPreviouslyOnArt(),
-            "onOrBefore=${onOrBefore},location=${location}"));
+            "onOrAfter=${onOrAfter},onOrBefore=${onOrBefore},location=${location}"));
     return dim;
   }
 


### PR DESCRIPTION
* MEPTS-424: Added a check to consider days when calculating difference between ART and IPT start dates

* MEPTS-424: Calculation should check if earliest isoniazid start date is in the previous 6 months

* MEPTS-434: Started ART query shoul check based on endDate of the current reporting period. See MEPTS-424 for details

* MEPTS-434: NewlyOrPreviouslyEnrolledOnARTCalculation should use the actual endDate parameter when querying for patients who start ART

Co-authored-by: Bailly RURANGIRWA <rubailly@gmail.com>

Co-authored-by: Paulo Sérgio Jaime Matsinhe <psmatsinhe@gmail.com>