### PR TITLE
MEPTS-440: Removed added one month after endDate and added a check for voided encounter when querying for observations

### DIFF
--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/prev/CompletedIsoniazidProphylaticTreatmentCalculation.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/prev/CompletedIsoniazidProphylaticTreatmentCalculation.java
@@ -43,7 +43,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class CompletedIsoniazidProphylaticTreatmentCalculation extends AbstractPatientCalculation {
 
-  private static final int COMPLETION_PERIOD_OFFSET = 1;
+  private static final int COMPLETION_PERIOD_OFFSET = 0;
 
   private static final int TREATMENT_BEGIN_PERIOD_OFFSET = -6;
 
@@ -148,13 +148,13 @@ public class CompletedIsoniazidProphylaticTreatmentCalculation extends AbstractP
 
       for (Integer patientId : cohort) {
         Obs startProfilaxiaObs =
-            EptsCalculationUtils.resultForPatient(startProfilaxiaObservations, patientId);
+            EptsCalculationUtils.obsResultForPatient(startProfilaxiaObservations, patientId);
         Obs startDrugsObs =
-            EptsCalculationUtils.resultForPatient(startDrugsObservations, patientId);
+            EptsCalculationUtils.obsResultForPatient(startDrugsObservations, patientId);
         Obs endProfilaxiaObs =
-            EptsCalculationUtils.resultForPatient(endProfilaxiaObservations, patientId);
+            EptsCalculationUtils.obsResultForPatient(endProfilaxiaObservations, patientId);
         Obs endDrugsObs =
-            EptsCalculationUtils.resultForPatient(completedDrugsObservations, patientId);
+            EptsCalculationUtils.obsResultForPatient(completedDrugsObservations, patientId);
         /**
          * If We can't find a startDate from Ficha de Seguimento (adults and children) / Ficha
          * Resumo or Ficha Clinica-MasterCard, we can't do the calculations. -Just move to the next

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/ResumoTrimestralCohortQueries.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/ResumoTrimestralCohortQueries.java
@@ -165,7 +165,7 @@ public class ResumoTrimestralCohortQueries {
     cd.addSearch("cohortG", mapStraightThrough(cohortG));
     cd.addSearch("viralLoadResult", mapStraightThrough(viralLoadResult));
     cd.setCompositionString("cohortG AND viralLoadResult");
-    
+
     return cd;
   }
 

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/utils/EptsCalculationUtils.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/utils/EptsCalculationUtils.java
@@ -184,6 +184,28 @@ public class EptsCalculationUtils {
   }
 
   /**
+   * Convenience method to fetch a patient result value
+   *
+   * @param results the calculation result map
+   * @param patientId the patient id
+   * @return the result value
+   */
+  @SuppressWarnings("unchecked")
+  public static <T> T obsResultForPatient(CalculationResultMap results, Integer patientId) {
+    CalculationResult result = results.get(patientId);
+    if (result != null && !result.isEmpty()) {
+      if ((T) result.getValue() instanceof Obs) {
+        Obs o = (Obs) result.getValue();
+        if (o.getEncounter().getVoided() == true) {
+          return null;
+        }
+      }
+      return (T) result.getValue();
+    }
+    return null;
+  }
+
+  /**
    * Extracts patients from calculation result map with matching results
    *
    * @param results calculation result map

--- a/api/src/test/java/org/openmrs/module/eptsreports/reporting/intergrated/calculation/prev/CompletedIsoniazidProphylaticTreatmentCalculationTest.java
+++ b/api/src/test/java/org/openmrs/module/eptsreports/reporting/intergrated/calculation/prev/CompletedIsoniazidProphylaticTreatmentCalculationTest.java
@@ -50,7 +50,7 @@ public class CompletedIsoniazidProphylaticTreatmentCalculationTest
 
     calendar.set(2018, Calendar.JULY, 1);
     context.addToCache("onOrAfter", calendar.getTime());
-    calendar.set(2018, Calendar.JULY, 2);
+    calendar.set(2019, Calendar.JULY, 2);
     context.addToCache("onOrBefore", calendar.getTime());
 
     final int patientId = 90;


### PR DESCRIPTION
- Removed one month that was added to endDate for previous specs

- When querying for obs, we have to check if the obs encounter is not voided. This will be handled by `#obsResultForPatient `in `EptsCalculationUtils` 