### PR TITLE
MEPTS-464: Updating javadoc for #positiveInvestigationResultComposition

### DIFF
--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/TXTBCohortQueries.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/TXTBCohortQueries.java
@@ -358,7 +358,7 @@ public class TXTBCohortQueries {
 
   /**
    * at least one “POS” selected for “Resultado da Investigação para TB de BK e/ou RX?”
-   * during the reporting period consultations; ( response 703: POS or for question: 6277)
+   * during the reporting period consultations; ( response 703: POS for question: 6277)
    */
   public CohortDefinition positiveInvestigationResultComposition() {
     CompositionCohortDefinition cd = new CompositionCohortDefinition();

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/TXTBCohortQueries.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/TXTBCohortQueries.java
@@ -357,8 +357,8 @@ public class TXTBCohortQueries {
   }
 
   /**
-   * at least one “POS” or “NEG” selected for “Resultado da Investigação para TB de BK e/ou RX?”
-   * during the reporting period consultations; ( response 703: POS or 664: NEG for question: 6277)
+   * at least one “POS” selected for “Resultado da Investigação para TB de BK e/ou RX?”
+   * during the reporting period consultations; ( response 703: POS or for question: 6277)
    */
   public CohortDefinition positiveInvestigationResultComposition() {
     CompositionCohortDefinition cd = new CompositionCohortDefinition();


### PR DESCRIPTION
The new specs are requesting the “NEG”  check to be removed but I found out that this was already implemented. There is nothing to change on the method apart from updating the JavaDoc comments to reflect this change.