### PR TITLE
MEPTS-466: Changed from using CodedObsCohortDefinition to using an SQL query to get patients with pulmonary TB date

### DIFF
--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/TXTBCohortQueries.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/TXTBCohortQueries.java
@@ -411,16 +411,19 @@ public class TXTBCohortQueries {
         "patientswithPulmonaryTbDate", map(patientswithPulmonaryTbDate, codedObsParameterMapping));
 
     CohortDefinition patientsWhoInitiatedTbTreatment =
-        TXTBQueries.getPatientsWithObsBetweenDates(
-            "Patients marked as Tratamento TB– Inicio (I)",
-            hivMetadata.getTBTreatmentPlanConcept(),
-            hivMetadata.getStartDrugs(),
-            Arrays.asList(
-                hivMetadata.getAdultoSeguimentoEncounterType(),
-                hivMetadata.getPediatriaSeguimentoEncounterType()));
+        genericCohortQueries.generalSql(
+            "patientsWhoInitiatedTbTreatment",
+            TXTBQueries.getPatientsWithObsBetweenDates(
+                hivMetadata.getTBTreatmentPlanConcept().getConceptId(),
+                hivMetadata.getStartDrugs().getConceptId(),
+                Arrays.asList(
+                    hivMetadata.getAdultoSeguimentoEncounterType().getEncounterTypeId(),
+                    hivMetadata.getPediatriaSeguimentoEncounterType().getEncounterTypeId())));
+    addGeneralParameters(patientsWhoInitiatedTbTreatment);
+
     cd.addSearch(
         "patientsWhoInitiatedTbTreatment",
-        map(patientsWhoInitiatedTbTreatment, codedObsParameterMapping));
+        map(patientsWhoInitiatedTbTreatment, generalParameterMapping));
 
     CohortDefinition artList = artList();
     cd.addSearch("artList", map(artList, generalParameterMapping));

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/queries/TXTBQueries.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/queries/TXTBQueries.java
@@ -505,16 +505,24 @@ public class TXTBQueries {
    */
   public static String getPatientsWithObsBetweenDates(
       Integer questionId, Integer valueId, List<Integer> encounterTypeIds) {
-    return String.format(
-        "SELECT p.patient_id FROM patient p INNER JOIN encounter e "
-            + "ON p.patient_id = e.patient_id "
-            + "INNER JOIN obs o "
-            + "ON e.encounter_id = o.encounter_id "
-            + "WHERE e.location_id = :location AND e.encounter_type in (%s) "
-            + "AND o.concept_id = %s  AND o.value_coded = %s "
-            + "AND o.obs_datetime >= :startDate AND o.obs_datetime <= :endDate "
-            + "AND p.voided = 0 AND e.voided = 0 AND o.voided = 0",
-        StringUtils.join(encounterTypeIds, ","), questionId, valueId);
+    StringBuilder s = new StringBuilder();
+    s.append("SELECT p.patient_id FROM patient p INNER JOIN encounter e ");
+    s.append("ON p.patient_id = e.patient_id ");
+    s.append("INNER JOIN obs o ");
+    s.append("ON e.encounter_id = o.encounter_id ");
+    s.append("WHERE e.location_id = :location AND e.encounter_type in (${encounterTypeIds}) ");
+    s.append("AND o.concept_id = ${questionId}  ");
+    s.append("AND o.value_coded = ${valueId} ");
+    s.append("AND o.obs_datetime >= :startDate AND o.obs_datetime <= :endDate ");
+    s.append("AND p.voided = 0 AND e.voided = 0 AND o.voided = 0");
+
+    Map<String, String> values = new HashMap<>();
+    values.put("encounterTypeIds", StringUtils.join(encounterTypeIds, ","));
+    // Just convert the conceptId to String so it can be added to the map
+    values.put("questionId", String.valueOf(questionId));
+    values.put("valueId", String.valueOf(valueId));
+    StringSubstitutor sb = new StringSubstitutor(values);
+    return sb.replace(s.toString());
   }
 
   public static class AbandonedWithoutNotificationParams {

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/queries/TXTBQueries.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/queries/TXTBQueries.java
@@ -490,6 +490,33 @@ public class TXTBQueries {
     return cd;
   }
 
+  /**
+   * Gets patients with a coded obs between dates. This method though might seem like a duplicate of
+   * the above method, We are adding it because we faced a situation where a patient had an obs with
+   * a wrong obs date time format (0209-10-22 00:00:00) Using CodedObsCohortDefinition from the
+   * above method was counting this patient. We had to resort to using an SQL query to get around
+   * this issue.
+   *
+   * @param questionId the obs concept Id
+   * @param valueId the obs value coded Id
+   * @param encounterTypeIds the obs's encounter enounter-type
+   * @return the query to execute. TODO Investigate why CodedObsCohortDefinition was not able to
+   *     handle this wrong date time format (0209-10-22 00:00:00)
+   */
+  public static String getPatientsWithObsBetweenDates(
+      Integer questionId, Integer valueId, List<Integer> encounterTypeIds) {
+    return String.format(
+        "SELECT p.patient_id FROM patient p INNER JOIN encounter e "
+            + "ON p.patient_id = e.patient_id "
+            + "INNER JOIN obs o "
+            + "ON e.encounter_id = o.encounter_id "
+            + "WHERE e.location_id = :location AND e.encounter_type in (%s) "
+            + "AND o.concept_id = %s  AND o.value_coded = %s "
+            + "AND o.obs_datetime >= :startDate AND o.obs_datetime <= :endDate "
+            + "AND p.voided = 0 AND e.voided = 0 AND o.voided = 0",
+        StringUtils.join(encounterTypeIds, ","), questionId, valueId);
+  }
+
   public static class AbandonedWithoutNotificationParams {
     protected Integer programId;
     protected Integer returnVisitDateConceptId;


### PR DESCRIPTION
- Added `#getPatientsWithObsBetweenDates` which uses an SQL query to get patients with pulmonary TB date.

- we faced a situation where a patient had an obs with a wrong obs date-time format (0209-10-22 00:00:00) Using CodedObsCohortDefinition from the above method was counting this patient. We had to resort to using an SQL query to get around this issue.