### PR TITLE
MEPTS-473: Removing TxML from semiannual report

### DIFF
--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/reports/SetupMERSemiAnnualReport.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/reports/SetupMERSemiAnnualReport.java
@@ -60,7 +60,6 @@ public class SetupMERSemiAnnualReport extends EptsDataExportManager {
     rd.setName(getName());
     rd.setDescription(getDescription());
     rd.setParameters(txMlDataset.getParameters());
-    rd.addDataSetDefinition("TXML", Mapped.mapStraightThrough(txMlDataset.constructtxMlDataset()));
     rd.addDataSetDefinition("T", Mapped.mapStraightThrough(txTBDataset.constructTxTBDataset()));
     rd.addDataSetDefinition("TBPREV", Mapped.mapStraightThrough(tbPrevDataset.constructDatset()));
     // add a base cohort to the report


### PR DESCRIPTION
This is just to remove the TxML from Semiannual report,
This is already part of other report so it will be run from there