### PR TITLE
MEPTS-470-numerator: Removed check for completed program exclusion

### DIFF
--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/queries/TXTBQueries.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/queries/TXTBQueries.java
@@ -134,7 +134,7 @@ public class TXTBQueries {
     return String.format(
         "select pg.patient_id from patient p inner join "
             + "patient_program pg on p.patient_id=pg.patient_id "
-            + "where pg.voided=0 and p.voided=0 and program_id=%s AND pg.date_completed is null "
+            + "where pg.voided=0 and p.voided=0 and program_id=%s "
             + "  and date_enrolled between :startDate and :endDate and location_id=:location",
         tbProgramId);
   }


### PR DESCRIPTION
After the call with Pinki, she confirmed that patients will still be included as long as they have been enrolled in the TB program even if they might have completed the program.
So in this PR, we are updating `#inTBProgramWithinReportingPeriodAtLocation()` by removing the check for completed program (`AND pg.date_completed is null)`