### PR TITLE
MEPTS-501 Fix Transferred-In query in PEPFAR Indicators - IM-ER4

### DIFF
--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/EriCohortQueries.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/EriCohortQueries.java
@@ -29,8 +29,6 @@ public class EriCohortQueries {
   @Autowired private HivMetadata hivMetadata;
 
   @Autowired private GenericCohortQueries genericCohortQueries;
-
-  @Autowired private HivCohortQueries hivCohortQueries;
   
   @Autowired private CommonCohortQueries commonCohortQueries;
 

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/EriCohortQueries.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/EriCohortQueries.java
@@ -13,7 +13,6 @@ package org.openmrs.module.eptsreports.reporting.library.cohorts;
 
 import java.util.Date;
 import org.openmrs.Location;
-import org.openmrs.module.eptsreports.metadata.HivMetadata;
 import org.openmrs.module.eptsreports.reporting.utils.EptsReportUtils;
 import org.openmrs.module.reporting.cohort.definition.CohortDefinition;
 import org.openmrs.module.reporting.cohort.definition.CompositionCohortDefinition;
@@ -26,10 +25,8 @@ public class EriCohortQueries {
 
   @Autowired private TxNewCohortQueries txNewCohortQueries;
 
-  @Autowired private HivMetadata hivMetadata;
-
   @Autowired private GenericCohortQueries genericCohortQueries;
-  
+
   @Autowired private CommonCohortQueries commonCohortQueries;
 
   /**

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/EriCohortQueries.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/EriCohortQueries.java
@@ -31,6 +31,8 @@ public class EriCohortQueries {
   @Autowired private GenericCohortQueries genericCohortQueries;
 
   @Autowired private HivCohortQueries hivCohortQueries;
+  
+  @Autowired private CommonCohortQueries commonCohortQueries;
 
   /**
    * Get all patients who initiated ART 2 months from ART initiation less transfer ins return the
@@ -47,7 +49,7 @@ public class EriCohortQueries {
     cd.addParameter(new Parameter("location", "Location", Location.class));
 
     CohortDefinition startedArtOnPeriod = genericCohortQueries.getStartedArtOnPeriod(false, true);
-    CohortDefinition transferIns = hivCohortQueries.getPatientsTransferredFromOtherHealthFacility();
+    CohortDefinition transferIns = commonCohortQueries.getMohTransferredInPatients();
 
     String mappings =
         "onOrAfter=${cohortStartDate},onOrBefore=${cohortEndDate},location=${location}";


### PR DESCRIPTION
Changes all IM-ER-Reports to use 15 MOH Transferred-in patients. Meaning that every occurrence of transferred-in used in IM-ER-Reports is now going to use query 15 MOH Transferred-in patients.