### PR TITLE
Remove the null pointer exception from the return visit date

### DIFF
--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/txcurr/ThreeToFiveMonthsOnArtDispensationCalculation.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/txcurr/ThreeToFiveMonthsOnArtDispensationCalculation.java
@@ -470,6 +470,7 @@ public class ThreeToFiveMonthsOnArtDispensationCalculation extends AbstractPatie
           && obsListForAllFila.size() > 0) {
         for (Obs obs : obsListForAllFila) {
           if (lastFilaEncounter.equals(obs.getEncounter())
+              && obs.getValueDatetime() != null
               && EptsCalculationUtils.daysSince(
                       obs.getEncounter().getEncounterDatetime(), obs.getValueDatetime())
                   >= 83

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/reports/SetupMERQuarterly24.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/reports/SetupMERQuarterly24.java
@@ -95,8 +95,7 @@ public class SetupMERQuarterly24 extends EptsDataExportManager {
     rd.setName(getName());
     rd.setDescription(getDescription());
     rd.setParameters(txPvlsDataset.getParameters());
-    // rd.addDataSetDefinition("N",
-    // Mapped.mapStraightThrough(txNewDataset.constructTxNewDataset()));
+    rd.addDataSetDefinition("N", Mapped.mapStraightThrough(txNewDataset.constructTxNewDataset()));
     rd.addDataSetDefinition(
         "C", Mapped.mapStraightThrough(txCurrDataset.constructTxCurrDataset(true)));
     rd.addDataSetDefinition("P", Mapped.mapStraightThrough(txPvlsDataset.constructTxPvlsDatset()));


### PR DESCRIPTION
Checking of null data incase of the return visit dates. Date comparison gets null pointer when there is a missing date for the fila encounters