### PR TITLE
Mepts 850 fixes

### DIFF
--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/rtt/ReturnedDateIITDateDaysCalculation.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/rtt/ReturnedDateIITDateDaysCalculation.java
@@ -4,8 +4,8 @@ import java.text.SimpleDateFormat;
 import java.util.*;
 import org.apache.commons.lang.time.DateUtils;
 import org.apache.commons.text.StringSubstitutor;
+import org.joda.time.DateTime;
 import org.joda.time.Days;
-import org.joda.time.Interval;
 import org.openmrs.Location;
 import org.openmrs.api.context.Context;
 import org.openmrs.calculation.patient.PatientCalculationContext;
@@ -62,7 +62,9 @@ public class ReturnedDateIITDateDaysCalculation extends AbstractPatientCalculati
       Date b = EptsCalculationUtils.resultForPatient(oldestDate, pId);
 
       if (a != null && b != null) {
-        int days = Days.daysIn(new Interval(a.getTime(), b.getTime())).getDays();
+        DateTime mostRecentDateTime = new DateTime(a.getTime());
+        DateTime oldestDateTime = new DateTime(b.getTime());
+        int days = Days.daysBetween(oldestDateTime, mostRecentDateTime).getDays();
         if (period == PLHIVDays.LESS_THAN_365) {
           if (days < YEAR_DAYS) {
             calculationResultMap.put(pId, new SimpleResult(days, this));

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/rtt/ReturnedDateIITDateDaysCalculation.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/rtt/ReturnedDateIITDateDaysCalculation.java
@@ -274,10 +274,7 @@ public class ReturnedDateIITDateDaysCalculation extends AbstractPatientCalculati
             + "' "
             + "                       GROUP  BY pa.patient_id "
             + "                   ) most_recent "
-            + "               GROUP BY most_recent.patient_id "
-            + "               HAVING final_encounter_date < '"
-            + endDate
-            + "' ";
+            + "               GROUP BY most_recent.patient_id ";
 
     StringSubstitutor stringSubstitutor1 = new StringSubstitutor(map1);
     return stringSubstitutor1.replace(query1);

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/rtt/ReturnedDateIITDateDaysCalculation.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/rtt/ReturnedDateIITDateDaysCalculation.java
@@ -65,14 +65,10 @@ public class ReturnedDateIITDateDaysCalculation extends AbstractPatientCalculati
         DateTime mostRecentDateTime = new DateTime(a.getTime());
         DateTime oldestDateTime = new DateTime(b.getTime());
         int days = Days.daysBetween(oldestDateTime, mostRecentDateTime).getDays();
-        if (period == PLHIVDays.LESS_THAN_365) {
-          if (days < YEAR_DAYS) {
-            calculationResultMap.put(pId, new SimpleResult(days, this));
-          }
-        } else if (period == PLHIVDays.MORE_THAN_365) {
-          if (days >= YEAR_DAYS) {
-            calculationResultMap.put(pId, new SimpleResult(days, this));
-          }
+        if (period == PLHIVDays.LESS_THAN_365 && days < YEAR_DAYS) {
+          calculationResultMap.put(pId, new SimpleResult(days, this));
+        } else if (period == PLHIVDays.MORE_THAN_365 && days >= YEAR_DAYS) {
+          calculationResultMap.put(pId, new SimpleResult(days, this));
         }
       } else if ((a == null || b == null) && period == PLHIVDays.UNKNOWN) {
         calculationResultMap.put(pId, new SimpleResult(null, this));

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/rtt/ReturnedDateIITDateDaysCalculation.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/calculation/rtt/ReturnedDateIITDateDaysCalculation.java
@@ -64,7 +64,7 @@ public class ReturnedDateIITDateDaysCalculation extends AbstractPatientCalculati
       if (a != null && b != null) {
         DateTime mostRecentDateTime = new DateTime(a.getTime());
         DateTime oldestDateTime = new DateTime(b.getTime());
-        int days = Days.daysBetween(oldestDateTime, mostRecentDateTime).getDays();
+        int days = Days.daysBetween(mostRecentDateTime, oldestDateTime).getDays();
         if (period == PLHIVDays.LESS_THAN_365 && days < YEAR_DAYS) {
           calculationResultMap.put(pId, new SimpleResult(days, this));
         } else if (period == PLHIVDays.MORE_THAN_365 && days >= YEAR_DAYS) {


### PR DESCRIPTION
Removed the having by clause that filtered patients who have a selected date less than the reporting date time, there cases where such dates are supposed to be higher than end of reporting end date, use case was to include this patient **19053**