### PR TITLE
MEPTS-1648| MQ CAT 9 changes March 2025 Release

### DIFF
--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/QualityImprovement2020CohortQueries.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/cohorts/QualityImprovement2020CohortQueries.java
@@ -13961,8 +13961,6 @@ public class QualityImprovement2020CohortQueries {
         "RESTARTED33DAYSBEFORE",
         EptsReportUtils.map(getPatientsRestartedWithLessThan33Days(), MAPPING3));
 
-    cd.addSearch("RESULTS", EptsReportUtils.map(getCd4ResultAfterRestartDate(), MAPPING3));
-
     if (denominator == 4) {
       cd.addSearch(
           "AGE",
@@ -13975,7 +13973,7 @@ public class QualityImprovement2020CohortQueries {
               genericCohortQueries.getAgeOnRestartedStateOfStayAndCd4Request(0, 14), MAPPING3));
     }
 
-    cd.setCompositionString("(RESTARTED AND RESULTS AND AGE) AND NOT RESTARTED33DAYSBEFORE");
+    cd.setCompositionString("(RESTARTED AND AGE) AND NOT RESTARTED33DAYSBEFORE");
 
     return cd;
   }

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/queries/QualityImprovement2020Queries.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/library/queries/QualityImprovement2020Queries.java
@@ -2691,7 +2691,7 @@ public class QualityImprovement2020Queries {
    */
   public static String getPatientsWithRestartedStateOfStayQuery() {
     return " SELECT p.patient_id, "
-        + "       Max(e.encounter_datetime) AS restart_date "
+        + "       Min(e.encounter_datetime) AS restart_date "
         + "FROM   patient p "
         + "           JOIN encounter e "
         + "                ON p.patient_id = e.patient_id "


### PR DESCRIPTION
This PR updates the logic for CD4 indicators:

Adjusts indicators 9.3, 9.4, 9.7, and 9.8 to consider the first restart record during the review period instead of the last.
Removes the CD4 result reception filter from indicators 9.4 and 9.8.